### PR TITLE
ci(release): tag automatically when a release branch merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release Tag
+
+# Tags a release when a release branch is merged to main, and pushes the tag.
+# Delegates to the reusable workflow in fleetbase/fleetbase. Requires org secret
+# _GITHUB_AUTH_TOKEN (inherited); no-ops with a warning until it is set.
+#
+# Branch convention is `release/v0.0.0`; the legacy `dev-v0.0.0` is still accepted so
+# branches opened before the rename still release.
+#
+# It pushes the tag and nothing else — whatever this repository already runs on
+# `push: tags: v*` does the publishing.
+#
+# The version is never retyped: it comes from the branch name, and the tag is refused
+# unless package.json and RELEASE.md already agree with it.
+#
+# RELEASE.md is required, and its first line must name the version being released. That
+# check is the only thing that can tell notes written for this release from the previous
+# release's notes nobody replaced.
+#
+# workflow_dispatch is the recovery path, for when a release fails validation and the fix
+# lands on main after the merge.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag, e.g. 1.2.3. Recovery only — a normal release reads it from the branch."
+        required: true
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    if: github.event_name == 'workflow_dispatch' ||
+        (github.event.pull_request.merged == true &&
+         (startsWith(github.event.pull_request.head.ref, 'release/v') ||
+          startsWith(github.event.pull_request.head.ref, 'dev-v')))
+    uses: fleetbase/fleetbase/.github/workflows/release-tag.yml@main
+    with:
+      version-files: package.json
+      version: ${{ github.event.inputs.version || '' }}
+    secrets: inherit

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+> v0.0.20 ~ "RELEASE_NOTES_PLACEHOLDER — replace this line with the release title"
+
+---
+## Highlights
+
+RELEASE_NOTES_PLACEHOLDER
+
+Describe what changed in this release. The first line above must name the version being
+released, and both placeholder markers must be gone, or the release workflow refuses to
+tag.
+
+---
+## Need help?
+- [GitHub Discussions](https://github.com/fleetbase/fleetbase/discussions)
+- [Discord](https://discord.gg/HnTqQ6zAVn)


### PR DESCRIPTION
Adds release-tag automation to this repository, using the `release/v0.0.0` branch convention. Companion to fleetbase/fleetbase#641, which holds the reusable workflow this delegates to.

## What it does

When a release branch is merged, it validates and pushes the tag — **and nothing else**. Whatever this repository already runs on `push: tags: v*` does the publishing, so there is no second release path.

The version is never retyped: it comes from the branch name (`release/v1.2.3` ⇒ `v1.2.3`), and the tag is refused unless every version file and `RELEASE.md` already agree with it.

## Validation, each failing rather than warning

- the PR was merged, not merely closed, from a `release/v<semver>` branch (legacy `dev-v<semver>` still accepted)
- every version file exists, yields a version, and matches
- `RELEASE.md` exists, is non-empty, and **its first line names this version**
- no `RELEASE_NOTES_PLACEHOLDER` marker remains
- no tag already exists at a different commit (same commit is a safe no-op)

The tag goes on the PR's merge commit, never on the default branch at run time.

## Also in this PR

A seeded `RELEASE.md`. The workflow refuses to release without notes whose first line names the version — that check is the only thing that can distinguish notes written for this release from the previous release's notes nobody replaced. **Replace both placeholder markers before your first release**, or the tag is refused.

## Merge order

**fleetbase/fleetbase#641 first**, since this references the reusable workflow at `@main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
